### PR TITLE
Update 0001_initial.py

### DIFF
--- a/django_password_validators/password_history/migrations/0001_initial.py
+++ b/django_password_validators/password_history/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             name='PasswordHistory',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('password', models.CharField(editable=False, max_length=256, verbose_name='Password hash')),
+                ('password', models.CharField(editable=False, max_length=255, verbose_name='Password hash')),
                 ('date', models.DateTimeField(auto_now_add=True, verbose_name='Date')),
             ],
             options={


### PR DESCRIPTION
Executing django-password-validators migrations on django 1.11.13, I got following error:
django.db.utils.OperationalError: (1071, 'Specified key was too long; max key length is 767 bytes')
Rrror is raised on migration 0001_inital .py, while executing last step:
        migrations.AlterUniqueTogether(
            name='passwordhistory',
            unique_together=set([('user_config', 'password')]),
        ),
I discover the issue, it is related to varchar length 256 in password. Even value is fixed later in migration 0002, it does not work in new installations.

May not the best solution, but so far I cannot find any other