### PR TITLE
Added history lookup range for the UniquePasswordsValidator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ In the file settings.py we add ::
    ]
    
    # 'lookup_range' sets how many previously used passwords to consider. 
-   # defaults to 3 if not set.
-   # It's a good practice to delete the password history.
+   # defaults to infinity if not set.
+   # Stored passwords outside the 'lookup_range' get deleted.
    # If you want, you can change the default hasher for the password history.
    # DPV_DEFAULT_HISTORY_HASHER = 'django_password_validators.password_history.hashers.HistoryHasher'
 

--- a/README.rst
+++ b/README.rst
@@ -48,13 +48,13 @@ In the file settings.py we add ::
        {
            'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
            'OPTIONS': {
-               'lookup_range': 3 
+               'lookup_range': 3
            }
        },
        ...
    ]
-   
-   # 'lookup_range' sets how many previously used passwords to consider. 
+
+   # 'lookup_range' sets how many previously used passwords to consider.
    # defaults to infinity if not set.
    # Stored passwords outside the 'lookup_range' get deleted.
    # If you want, you can change the default hasher for the password history.

--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,16 @@ In the file settings.py we add ::
        ...
        {
            'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+           'OPTIONS': {
+               'lookup_range': 3 
+           }
        },
        ...
    ]
-
+   
+   # 'lookup_range' sets how many previously used passwords to consider. 
+   # defaults to 3 if not set.
+   # It's a good practice to delete the password history.
    # If you want, you can change the default hasher for the password history.
    # DPV_DEFAULT_HISTORY_HASHER = 'django_password_validators.password_history.hashers.HistoryHasher'
 

--- a/django_password_validators/password_history/password_validation.py
+++ b/django_password_validators/password_history/password_validation.py
@@ -54,7 +54,7 @@ class UniquePasswordsValidator(object):
                     raise PasswordHistory.DoesNotExist
 
                 current_user_passwords = PasswordHistory.objects.filter(
-                    user_config=user_config).order_by('-date')
+                    user_config=user_config).order_by('date')
 
                 if self.lookup_range >= len(current_user_passwords):
                     PasswordHistory.objects.get(
@@ -63,12 +63,13 @@ class UniquePasswordsValidator(object):
                     )
                 else:
                     # At this point, there are passwords we have to delete
-                    for entry in current_user_passwords[self.lookup_range:]:
+                    for entry in current_user_passwords[:len(
+                            current_user_passwords) - self.lookup_range]:
                         entry.delete()
 
-                    if any(entry.user_config == user_config and
-                           entry.password == password
-                           for entry in current_user_passwords[:self.lookup_range]):
+                    if any([entry.user_config == user_config and
+                            entry.password == password
+                            for entry in current_user_passwords[len(current_user_passwords) - self.lookup_range:]]):
                         raise ValidationError(
                             _("You cannot use a password that was recently used in this application."),
                             code='password_used')

--- a/tests/test_project/tests/base.py
+++ b/tests/test_project/tests/base.py
@@ -24,6 +24,15 @@ class PasswordsTestCase(TestCase):
         user.set_password(self.PASSWORD_TEMPLATE % password_number)
         user.save()
 
+    def user_change_password_number_of_times(self, user_number, num_of_times):
+        """
+        Performs 'num_of_times' password changes for the test user
+        """
+        user = self.UserModel.objects.get(username='test%d' % user_number)
+        for i in range(num_of_times):
+            user.set_password(self.PASSWORD_TEMPLATE % i)
+            user.save()
+
     def assert_password_validation_True(self, user_number, password_number):
         user = self.UserModel.objects.get(username='test%d' % user_number)
         validate_password(
@@ -45,6 +54,17 @@ class PasswordsTestCase(TestCase):
                     return
             else:
                 raise e
+
+    def assert_password_validation_number_of_times(self, user_number, num_of_times, to_assert):
+        """
+        Asserts password validation is False a 'num_of_times' for the test user
+        """
+        if to_assert:
+            for i in range(num_of_times):
+                self.assert_password_validation_True(user_number=user_number, password_number=i)
+        else:
+            for i in range(num_of_times):
+                self.assert_password_validation_False(user_number=user_number, password_number=i)
 
     def setUp(self):
         self.UserModel = get_user_model()

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -12,7 +12,7 @@ from django_password_validators.password_history.models import (
     UserPasswordHistoryConfig,
     PasswordHistory
 )
-
+from copy import copy
 from .base import PasswordsTestCase
 
 
@@ -104,11 +104,11 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
-            'lookup_range': 5 
-        }  
+            'lookup_range': 5
+        }
     }])
     def test_lookup_range_true_positive(self):
-        # We're considering the last 5 passwords
+        # We're considering the last 5 passwords and setting a valid password
         self.create_user(1)
         self.user_change_password(user_number=1, password_number=1)
         self.user_change_password(user_number=1, password_number=2)
@@ -122,10 +122,10 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
             'lookup_range': 2
-        }  
+        }
     }])
     def test_lookup_range_true_negative(self):
-        # We're considering the last 2 passwords
+        # We're considering the last 2 passwords, setting an invalid password
         self.create_user(1)
         self.user_change_password(user_number=1, password_number=1)
         self.user_change_password(user_number=1, password_number=2)
@@ -140,10 +140,10 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
             'lookup_range': 1
-        }  
+        }
     }])
     def test_lookup_range_last_password(self):
-        # Considers the last password
+        # Considers only the last password
         self.create_user(1)
         self.user_change_password(user_number=1, password_number=1)
         self.user_change_password(user_number=1, password_number=2)
@@ -157,7 +157,7 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
             'lookup_range': 0
-        }  
+        }
     }])
     def test_lookup_range_zero(self):
         # If it's a 0, we're considering no passwords
@@ -176,7 +176,7 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
             'lookup_range': -3
-        }  
+        }
     }])
     def test_lookup_range_invalid(self):
         # If it's negative, defaults to all the passwords
@@ -188,3 +188,63 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         self.assert_password_validation_False(user_number=1, password_number=2)
         self.assert_password_validation_False(user_number=1, password_number=3)
         self.assert_password_validation_True(user_number=1, password_number=4)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 2
+        }
+    }])
+    def test_delete_history_in_lookup_range(self):
+        # Older passwords outside of lookup_range are deleted
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.assertEqual(PasswordHistory.objects.count(), 1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.assertEqual(PasswordHistory.objects.count(), 2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assertEqual(PasswordHistory.objects.count(), 2)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 2
+        }
+    }])
+    def test_delete_history_in_lookup_range(self):
+        # Passwords are deleted by ordering of date, not just position
+        lookup_range = 2
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+
+        considered_passwords = copy(list(PasswordHistory.objects.all()))
+
+        self.assertEqual(
+            len(considered_passwords),
+            lookup_range
+        )
+        self.assertEqual(
+            considered_passwords,
+            list(PasswordHistory.objects.all().order_by('date'))
+        )
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 16
+        }
+    }])
+    def test_delete_history_in_large_lookup_range(self):
+        # Ensures that if lookup_range > count of PasswordHistory works
+        # correctly
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+        self.assert_password_validation_True(user_number=1, password_number=5)

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_password_validators.password_history.password_validation import UniquePasswordsValidator
 from django_password_validators.password_history.hashers import (
@@ -100,3 +100,91 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
                     user_config__iterations=HistoryVeryStrongHasher.iterations).count(),
                 1,
             )
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 5 
+        }  
+    }])
+    def test_lookup_range_true_positive(self):
+        # We're considering the last 5 passwords
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+        self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=4)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 2
+        }  
+    }])
+    def test_lookup_range_true_negative(self):
+        # We're considering the last 2 passwords
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.assert_password_validation_False(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+        self.assert_password_validation_True(user_number=1, password_number=3)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 1
+        }  
+    }])
+    def test_lookup_range_last_password(self):
+        # Considers the last password
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.assert_password_validation_True(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 0
+        }  
+    }])
+    def test_lookup_range_zero(self):
+        # If it's a 0, we're considering no passwords
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=1)
+        self.assert_password_validation_True(user_number=1, password_number=2)
+        self.assert_password_validation_True(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+        self.user_change_password(user_number=1, password_number=4)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': -3
+        }  
+    }])
+    def test_lookup_range_invalid(self):
+        # If it's negative, defaults to all the passwords
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=1)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+        self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=4)

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -104,19 +104,33 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
         'OPTIONS': {
-            'lookup_range': 5
+            'lookup_range': 3
         }
     }])
-    def test_lookup_range_true_positive(self):
-        # We're considering the last 5 passwords and setting a valid password
+    def test_lookup_range(self):
+        """Tests considering the last 3 passwords and setting a valid password."""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
-        self.assert_password_validation_False(user_number=1, password_number=1)
-        self.assert_password_validation_False(user_number=1, password_number=2)
-        self.assert_password_validation_False(user_number=1, password_number=3)
-        self.assert_password_validation_False(user_number=1, password_number=4)
+        for i in range(4):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(4):
+            self.assert_password_validation_False(
+                user_number=1, password_number=i)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+
+    def test_lookup_range_string(self):
+        """Tests that a TypeError is raised if lookup_range is not an integer."""
+        with self.assertRaises(TypeError) as context:
+            validator = UniquePasswordsValidator(lookup_range='something')
+
+    def test_lookup_range_dictionary(self):
+        """Tests that a TypeError is raised if lookup_range is not an integer."""
+        with self.assertRaises(TypeError) as context:
+            validator = UniquePasswordsValidator(lookup_range={'foo': 1})
+
+    def test_lookup_range_list(self):
+        """Tests that a TypeError is raised if lookup_range is not an integer."""
+        with self.assertRaises(TypeError) as context:
+            validator = UniquePasswordsValidator(lookup_range=[2])
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
@@ -124,15 +138,22 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
             'lookup_range': 2
         }
     }])
-    def test_lookup_range_true_negative(self):
-        # We're considering the last 2 passwords, setting an invalid password
+    def test_lookup_range_change_then_retry(self):
+        """Tests considering the last 2 passwords, entering a valid third one
+        then confirming it's no longer valid
+        """
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.assert_password_validation_False(user_number=1, password_number=1)
-        self.assert_password_validation_False(user_number=1, password_number=2)
+        for i in range(3):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(3):
+            self.assert_password_validation_False(
+                user_number=1, password_number=i)
         self.assert_password_validation_True(user_number=1, password_number=3)
         self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=2)
+
+        # password_number=1 should now be valid as it was deleted
+        self.assert_password_validation_True(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=3)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
@@ -143,10 +164,10 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_last_password(self):
-        # Considers only the last password
+        """Tests considering only the last password"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
+        for i in range(3):
+            self.user_change_password(user_number=1, password_number=i)
         self.assert_password_validation_True(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=2)
         self.user_change_password(user_number=1, password_number=3)
@@ -160,15 +181,13 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_zero(self):
-        # If it's a 0, we're considering no passwords
+        """Tests that if lookup_range == 0, we're considering no passwords"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
-        self.assert_password_validation_True(user_number=1, password_number=1)
-        self.assert_password_validation_True(user_number=1, password_number=2)
-        self.assert_password_validation_True(user_number=1, password_number=3)
-        self.assert_password_validation_True(user_number=1, password_number=4)
+        for i in range(4):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(5):
+            self.assert_password_validation_True(
+                user_number=1, password_number=i)
         self.user_change_password(user_number=1, password_number=4)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
@@ -179,14 +198,13 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_invalid(self):
-        # If it's negative, defaults to all the passwords
+        """Tests that if lookup_range is negative, defaults to all the passwords"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
-        self.assert_password_validation_False(user_number=1, password_number=1)
-        self.assert_password_validation_False(user_number=1, password_number=2)
-        self.assert_password_validation_False(user_number=1, password_number=3)
+        for i in range(3):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(4):
+            self.assert_password_validation_False(
+                user_number=1, password_number=i)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
@@ -196,14 +214,30 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_in_lookup_range(self):
-        # Older passwords outside of lookup_range are deleted
+        """Tests that older passwords outside of lookup_range are deleted whenever a validation takes place"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
         self.assertEqual(PasswordHistory.objects.count(), 1)
         self.user_change_password(user_number=1, password_number=2)
         self.assertEqual(PasswordHistory.objects.count(), 2)
         self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=3)
         self.assertEqual(PasswordHistory.objects.count(), 2)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 12
+        }
+    }])
+    def test_dont_delete_history_in_lookup_range(self):
+        """Tests that older passwords inside of lookup_range are not deleted whenever a validation takes place"""
+        self.create_user(1)
+        self.assertEqual(PasswordHistory.objects.count(), 1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.assertEqual(PasswordHistory.objects.count(), 2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assertEqual(PasswordHistory.objects.count(), 3)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
@@ -211,25 +245,36 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
             'lookup_range': 2
         }
     }])
-    def test_delete_history_in_lookup_range(self):
-        # Passwords are deleted by ordering of date, not just position
+    def test_delete_history_by_dates(self):
+        """Tests that passwords are deleted by ordering of date,
+        not just position, and the correct ones are deleted"""
         lookup_range = 2
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
-        self.assert_password_validation_True(user_number=1, password_number=1)
-        self.assert_password_validation_False(user_number=1, password_number=2)
+        for i in range(5):
+            self.user_change_password(user_number=1, password_number=i)
 
-        considered_passwords = copy(list(PasswordHistory.objects.all()))
-        considered_passwords.reverse()
+        all_passwords = list(PasswordHistory.objects.all().order_by('date'))
+
+        self.assert_password_validation_False(user_number=1, password_number=4)
+        self.assert_password_validation_True(user_number=1, password_number=5)
+
+        passwords_to_delete = all_passwords[:len(
+            all_passwords) - lookup_range]
+        passwords_to_lookup = all_passwords[len(all_passwords) - lookup_range:]
+
+        for entry in passwords_to_delete:
+            with self.assertRaises(PasswordHistory.DoesNotExist) as context:
+                entry.refresh_from_db()
+                self.assertTrue(
+                    'PasswordHistory.DoesNotExist' in str(
+                        context.exception))
 
         self.assertEqual(
-            len(considered_passwords),
+            len(passwords_to_lookup),
             lookup_range
         )
         self.assertEqual(
-            considered_passwords,
+            passwords_to_lookup,
             list(PasswordHistory.objects.all().order_by('date'))
         )
 
@@ -240,15 +285,30 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_in_large_lookup_range(self):
-        # Ensures that if lookup_range > count of PasswordHistory works
-        # correctly
+        """Tests that if lookup_range > count of PasswordHistory, the validator doesn't delete any"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=1)
+        self.assertEqual(PasswordHistory.objects.count(), 1)
+        for i in range(4):
+            self.user_change_password(user_number=1, password_number=i)
+        self.assertEqual(PasswordHistory.objects.count(), 4)
         self.assert_password_validation_False(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=2)
         self.assert_password_validation_True(user_number=1, password_number=5)
+        self.assertEqual(PasswordHistory.objects.count(), 4)
+
+    def test_lookup_range_undefined(self):
+        """Tests that lookup_range defaults to infinite if undefined"""
+        self.create_user(1)
+        validator = UniquePasswordsValidator()
+        lookup_range = validator.lookup_range
+        self.assertEqual(lookup_range, float('inf'))
+        for i in range(4):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(4):
+            self.assert_password_validation_False(
+                user_number=1, password_number=i)
+        self.assert_password_validation_True(user_number=1, password_number=4)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
@@ -257,22 +317,13 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_many_entries(self):
-        # Ensures that if lookup_range works well with many password
-        # entries
+        """Tests that if lookup_range works well with many password entries"""
         self.create_user(1)
-        self.user_change_password(user_number=1, password_number=1)
-        self.user_change_password(user_number=1, password_number=2)
-        self.user_change_password(user_number=1, password_number=3)
-        self.user_change_password(user_number=1, password_number=4)
-        self.user_change_password(user_number=1, password_number=5)
-        self.user_change_password(user_number=1, password_number=6)
-        self.user_change_password(user_number=1, password_number=7)
-        self.user_change_password(user_number=1, password_number=8)
-        self.assert_password_validation_True(user_number=1, password_number=1)
-        self.assert_password_validation_True(user_number=1, password_number=2)
-        self.assert_password_validation_True(user_number=1, password_number=3)
-        self.assert_password_validation_True(user_number=1, password_number=4)
-        self.assert_password_validation_True(user_number=1, password_number=5)
-        self.assert_password_validation_False(user_number=1, password_number=6)
-        self.assert_password_validation_False(user_number=1, password_number=7)
-        self.assert_password_validation_False(user_number=1, password_number=8)
+        for i in range(9):
+            self.user_change_password(user_number=1, password_number=i)
+        for i in range(6):
+            self.assert_password_validation_True(
+                user_number=1, password_number=i)
+        for i in range(6, 9):
+            self.assert_password_validation_False(
+                user_number=1, password_number=i)

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -12,7 +12,7 @@ from django_password_validators.password_history.models import (
     UserPasswordHistoryConfig,
     PasswordHistory
 )
-from copy import copy
+
 from .base import PasswordsTestCase
 
 
@@ -108,29 +108,27 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range(self):
-        """Tests considering the last 3 passwords and setting a valid password."""
+        """
+        Tests considering the last 3 passwords and setting a valid password.
+        """
         self.create_user(1)
-        for i in range(4):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(4):
-            self.assert_password_validation_False(
-                user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=4)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=4, to_assert=False)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
-    def test_lookup_range_string(self):
-        """Tests that a TypeError is raised if lookup_range is not an integer."""
-        with self.assertRaises(TypeError) as context:
-            validator = UniquePasswordsValidator(lookup_range='something')
+    def test_lookup_range_not_an_int(self):
+        """
+        Tests that a TypeError is raised if lookup_range
+        is not an integer (considering string, list and dict).
+        """
+        with self.assertRaises(TypeError):
+            UniquePasswordsValidator(lookup_range='something')
 
-    def test_lookup_range_dictionary(self):
-        """Tests that a TypeError is raised if lookup_range is not an integer."""
-        with self.assertRaises(TypeError) as context:
-            validator = UniquePasswordsValidator(lookup_range={'foo': 1})
+        with self.assertRaises(TypeError):
+            UniquePasswordsValidator(lookup_range={'foo': 1})
 
-    def test_lookup_range_list(self):
-        """Tests that a TypeError is raised if lookup_range is not an integer."""
-        with self.assertRaises(TypeError) as context:
-            validator = UniquePasswordsValidator(lookup_range=[2])
+        with self.assertRaises(TypeError):
+            UniquePasswordsValidator(lookup_range=[2])
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
         'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
@@ -139,15 +137,13 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_change_then_retry(self):
-        """Tests considering the last 2 passwords, entering a valid third one
+        """
+        Tests considering the last 2 passwords, entering a valid third one
         then confirming it's no longer valid
         """
         self.create_user(1)
-        for i in range(3):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(3):
-            self.assert_password_validation_False(
-                user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=3)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=3, to_assert=False)
         self.assert_password_validation_True(user_number=1, password_number=3)
         self.user_change_password(user_number=1, password_number=3)
         self.assert_password_validation_False(user_number=1, password_number=2)
@@ -164,10 +160,11 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_last_password(self):
-        """Tests considering only the last password"""
+        """
+        Tests considering only the last password
+        """
         self.create_user(1)
-        for i in range(3):
-            self.user_change_password(user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=3)
         self.assert_password_validation_True(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=2)
         self.user_change_password(user_number=1, password_number=3)
@@ -181,13 +178,12 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_zero(self):
-        """Tests that if lookup_range == 0, we're considering no passwords"""
+        """
+        Tests that if lookup_range == 0, we're considering no passwords
+        """
         self.create_user(1)
-        for i in range(4):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(5):
-            self.assert_password_validation_True(
-                user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=4)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=5, to_assert=False)
         self.user_change_password(user_number=1, password_number=4)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
@@ -198,13 +194,12 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_lookup_range_invalid(self):
-        """Tests that if lookup_range is negative, defaults to all the passwords"""
+        """
+        Tests that if lookup_range is negative, defaults to all the passwords
+        """
         self.create_user(1)
-        for i in range(3):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(4):
-            self.assert_password_validation_False(
-                user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=3)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=4, to_assert=False)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
@@ -214,7 +209,9 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_in_lookup_range(self):
-        """Tests that older passwords outside of lookup_range are deleted whenever a validation takes place"""
+        """
+        Tests that older passwords outside of lookup_range are deleted whenever a validation takes place
+        """
         self.create_user(1)
         self.assertEqual(PasswordHistory.objects.count(), 1)
         self.user_change_password(user_number=1, password_number=2)
@@ -230,7 +227,9 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_dont_delete_history_in_lookup_range(self):
-        """Tests that older passwords inside of lookup_range are not deleted whenever a validation takes place"""
+        """
+        Tests that older passwords inside of lookup_range are not deleted whenever a validation takes place
+        """
         self.create_user(1)
         self.assertEqual(PasswordHistory.objects.count(), 1)
         self.user_change_password(user_number=1, password_number=2)
@@ -246,20 +245,22 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_by_dates(self):
-        """Tests that passwords are deleted by ordering of date,
-        not just position, and the correct ones are deleted"""
+        """
+        Tests that passwords are deleted by ordering of date,
+        not just position, and the correct ones are deleted
+        """
         lookup_range = 2
         self.create_user(1)
-        for i in range(5):
-            self.user_change_password(user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=5)
 
         all_passwords = list(PasswordHistory.objects.all().order_by('date'))
 
         self.assert_password_validation_False(user_number=1, password_number=4)
         self.assert_password_validation_True(user_number=1, password_number=5)
 
-        passwords_to_delete = all_passwords[:len(
-            all_passwords) - lookup_range]
+        passwords_to_delete = all_passwords[
+            :len(all_passwords) - lookup_range
+        ]
         passwords_to_lookup = all_passwords[len(all_passwords) - lookup_range:]
 
         for entry in passwords_to_delete:
@@ -267,7 +268,8 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
                 entry.refresh_from_db()
                 self.assertTrue(
                     'PasswordHistory.DoesNotExist' in str(
-                        context.exception))
+                        context.exception)
+                    )
 
         self.assertEqual(
             len(passwords_to_lookup),
@@ -285,12 +287,13 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_in_large_lookup_range(self):
-        """Tests that if lookup_range > count of PasswordHistory, the validator doesn't delete any"""
+        """
+        Tests that if lookup_range > count of PasswordHistory, the validator doesn't delete any
+        """
         self.create_user(1)
         self.assert_password_validation_False(user_number=1, password_number=1)
         self.assertEqual(PasswordHistory.objects.count(), 1)
-        for i in range(4):
-            self.user_change_password(user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=4)
         self.assertEqual(PasswordHistory.objects.count(), 4)
         self.assert_password_validation_False(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=2)
@@ -298,16 +301,14 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         self.assertEqual(PasswordHistory.objects.count(), 4)
 
     def test_lookup_range_undefined(self):
-        """Tests that lookup_range defaults to infinite if undefined"""
+        """
+        Tests that lookup_range defaults to None (all passwords) if undefined
+        """
         self.create_user(1)
         validator = UniquePasswordsValidator()
         lookup_range = validator.lookup_range
         self.assertEqual(lookup_range, float('inf'))
-        for i in range(4):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(4):
-            self.assert_password_validation_False(
-                user_number=1, password_number=i)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=4, to_assert=False)
         self.assert_password_validation_True(user_number=1, password_number=4)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{
@@ -317,13 +318,27 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         }
     }])
     def test_delete_history_many_entries(self):
-        """Tests that if lookup_range works well with many password entries"""
+        """
+        Tests that if lookup_range works well with many password entries
+        """
         self.create_user(1)
-        for i in range(9):
-            self.user_change_password(user_number=1, password_number=i)
-        for i in range(6):
-            self.assert_password_validation_True(
-                user_number=1, password_number=i)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=9)
+        self.assert_password_validation_number_of_times(user_number=1, num_of_times=6, to_assert=True)
         for i in range(6, 9):
             self.assert_password_validation_False(
-                user_number=1, password_number=i)
+                user_number=1, password_number=i
+            )
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 2
+        }
+    }])
+    def test_delete_history_and_invalid_password(self):
+        """
+        Tests submiting one of the remaining passwords after deletion raises an exception
+        """
+        self.create_user(1)
+        self.user_change_password_number_of_times(user_number=1, num_of_times=4)
+        self.assert_password_validation_False(user_number=1, password_number=3)

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -217,7 +217,9 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         self.user_change_password(user_number=1, password_number=2)
         self.assertEqual(PasswordHistory.objects.count(), 2)
         self.user_change_password(user_number=1, password_number=3)
+        self.assert_password_validation_False(user_number=1, password_number=2)
         self.assert_password_validation_False(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=1)
         self.assertEqual(PasswordHistory.objects.count(), 2)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[{

--- a/tests/test_project/tests/test_password_history.py
+++ b/tests/test_project/tests/test_password_history.py
@@ -222,6 +222,7 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         self.assert_password_validation_False(user_number=1, password_number=2)
 
         considered_passwords = copy(list(PasswordHistory.objects.all()))
+        considered_passwords.reverse()
 
         self.assertEqual(
             len(considered_passwords),
@@ -248,3 +249,30 @@ class UniquePasswordsValidatorTestCase(PasswordsTestCase):
         self.assert_password_validation_False(user_number=1, password_number=1)
         self.assert_password_validation_False(user_number=1, password_number=2)
         self.assert_password_validation_True(user_number=1, password_number=5)
+
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django_password_validators.password_history.password_validation.UniquePasswordsValidator',
+        'OPTIONS': {
+            'lookup_range': 3
+        }
+    }])
+    def test_delete_history_many_entries(self):
+        # Ensures that if lookup_range works well with many password
+        # entries
+        self.create_user(1)
+        self.user_change_password(user_number=1, password_number=1)
+        self.user_change_password(user_number=1, password_number=2)
+        self.user_change_password(user_number=1, password_number=3)
+        self.user_change_password(user_number=1, password_number=4)
+        self.user_change_password(user_number=1, password_number=5)
+        self.user_change_password(user_number=1, password_number=6)
+        self.user_change_password(user_number=1, password_number=7)
+        self.user_change_password(user_number=1, password_number=8)
+        self.assert_password_validation_True(user_number=1, password_number=1)
+        self.assert_password_validation_True(user_number=1, password_number=2)
+        self.assert_password_validation_True(user_number=1, password_number=3)
+        self.assert_password_validation_True(user_number=1, password_number=4)
+        self.assert_password_validation_True(user_number=1, password_number=5)
+        self.assert_password_validation_False(user_number=1, password_number=6)
+        self.assert_password_validation_False(user_number=1, password_number=7)
+        self.assert_password_validation_False(user_number=1, password_number=8)


### PR DESCRIPTION
Hi!

We added a `lookup_range` parameter to the `UniquePasswordsValidator`, so it looks up the last N elements. These are the considered cases:

- `N > 0`: Considers the last N passwords (you can set it to 1)
- `N = 0`: No passwords considered, anything goes!

Considered error cases:
- `N < 0`: Defaults to all passwords.
- `N is not an int`: The user set this wrong, Python will raise an exception.
- `lookup_range is not defined`: Defaults to 3, which is pretty common; I kept the validator running because if you installed it, it means you expect it to work, you just didn't read the README :).

Let me know what you think, @fizista ! I didn't run any linters, so do tell if it's necessary. Thank you for developing this project; it was a breeze to work on! 
**However**, I would like to ask you, if you see everything right, to bump the version. 

CC: @lgp171188