### PR TITLE
Add exception handling for gettext import in Django 4

### DIFF
--- a/django_password_validators/password_character_requirements/password_validation.py
+++ b/django_password_validators/password_character_requirements/password_validation.py
@@ -1,5 +1,8 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _, ungettext
+try:
+  from django.utils.translation import gettext as _, ungettext
+except ImportError:
+  from django.utils.translation import ugettext as _, ungettext
 
 
 class PasswordCharacterValidator():

--- a/django_password_validators/password_character_requirements/password_validation.py
+++ b/django_password_validators/password_character_requirements/password_validation.py
@@ -1,8 +1,8 @@
 from django.core.exceptions import ValidationError
 try:
-  from django.utils.translation import gettext as _, ungettext
+  from django.utils.translation import gettext as _, ngettext
 except ImportError:
-  from django.utils.translation import ugettext as _, ungettext
+  from django.utils.translation import ugettext as _, ungettext as ngettext
 
 
 class PasswordCharacterValidator():
@@ -27,7 +27,7 @@ class PasswordCharacterValidator():
         validation_errors = []
         if len([char for char in password if char.isdigit()]) < self.min_length_digit:
             validation_errors.append(ValidationError(
-                ungettext(
+                ngettext(
                     'This password must contain at least %(min_length)d digit.',
                     'This password must contain at least %(min_length)d digits.',
                     self.min_length_digit
@@ -37,7 +37,7 @@ class PasswordCharacterValidator():
             ))
         if len([char for char in password if char.isalpha()]) < self.min_length_alpha:
             validation_errors.append(ValidationError(
-                ungettext(
+                ngettext(
                     'This password must contain at least %(min_length)d letter.',
                     'This password must contain at least %(min_length)d letters.',
                     self.min_length_alpha
@@ -47,7 +47,7 @@ class PasswordCharacterValidator():
             ))
         if len([char for char in password if char.isupper()]) < self.min_length_upper:
             validation_errors.append(ValidationError(
-                ungettext(
+                ngettext(
                     'This password must contain at least %(min_length)d upper case letter.',
                     'This password must contain at least %(min_length)d upper case letters.',
                     self.min_length_upper
@@ -57,7 +57,7 @@ class PasswordCharacterValidator():
             ))
         if len([char for char in password if char.islower()]) < self.min_length_lower:
             validation_errors.append(ValidationError(
-                ungettext(
+                ngettext(
                     'This password must contain at least %(min_length)d lower case letter.',
                     'This password must contain at least %(min_length)d lower case letters.',
                     self.min_length_lower
@@ -67,7 +67,7 @@ class PasswordCharacterValidator():
             ))
         if len([char for char in password if char in self.special_characters]) < self.min_length_special:
             validation_errors.append(ValidationError(
-                ungettext(
+                ngettext(
                     'This password must contain at least %(min_length)d special character.',
                     'This password must contain at least %(min_length)d special characters.',
                     self.min_length_special
@@ -82,7 +82,7 @@ class PasswordCharacterValidator():
         validation_req = []
         if self.min_length_alpha:
             validation_req.append(
-                ungettext(
+                ngettext(
                     "%(min_length)s letter",
                     "%(min_length)s letters",
                     self.min_length_alpha
@@ -90,7 +90,7 @@ class PasswordCharacterValidator():
             )
         if self.min_length_digit:
             validation_req.append(
-                ungettext(
+                ngettext(
                     "%(min_length)s digit",
                     "%(min_length)s digits",
                     self.min_length_digit
@@ -98,7 +98,7 @@ class PasswordCharacterValidator():
             )
         if self.min_length_lower:
             validation_req.append(
-                ungettext(
+                ngettext(
                     "%(min_length)s lower case letter",
                     "%(min_length)s lower case letters",
                     self.min_length_lower
@@ -106,7 +106,7 @@ class PasswordCharacterValidator():
             )
         if self.min_length_upper:
             validation_req.append(
-                ungettext(
+                ngettext(
                     "%(min_length)s upper case letter",
                     "%(min_length)s upper case letters",
                     self.min_length_upper
@@ -114,7 +114,7 @@ class PasswordCharacterValidator():
             )
         if self.special_characters:
             validation_req.append(
-                ungettext(
+                ngettext(
                     "%(min_length_special)s special character, such as %(special_characters)s",
                     "%(min_length_special)s special characters, such as %(special_characters)s",
                     self.min_length_special

--- a/django_password_validators/password_history/models.py
+++ b/django_password_validators/password_history/models.py
@@ -2,7 +2,10 @@
 from django.conf import settings
 from django.db import models
 from django.utils.crypto import get_random_string
-from django.utils.translation import ugettext_lazy as _
+try:
+  from django.utils.translation import gettext_lazy as _
+except ImportError:
+  from django.utils.translation import ugettext_lazy as _
 
 from django_password_validators.settings import get_password_hasher
 

--- a/django_password_validators/password_history/password_validation.py
+++ b/django_password_validators/password_history/password_validation.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 import warnings
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _, ngettext
+try:
+  from django.utils.translation import gettext as _, ngettext
+except ImportError:
+  from django.utils.translation import ugettext as _, ngettext
 from django_password_validators.settings import get_password_hasher
 from django_password_validators.password_history.models import (
     PasswordHistory,


### PR DESCRIPTION
Django 3 deprecated the `ugettext` function & aliased it to `gettext`.

Django 4 has removed it.

This retains backwards compatibility with Django 2 (as per library requirements) by trying to import different modules.

Helps to fix: https://github.com/fizista/django-password-validators/issues/25