### PR TITLE
Add default_auto_field in apps config

### DIFF
--- a/django_password_validators/password_history/apps.py
+++ b/django_password_validators/password_history/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PasswordHistoryConfig(AppConfig):
+    name = 'django_password_validators.password_history'
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
We need to set default_auto_field in the app config to prevent getting messages about missing migrations if in a project  DEFAULT_AUTO_FIELD is set to BigAutoField.

Fixes #29