### PR TITLE
Setup CI using GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+        shell: bash
+      - name: Run tests
+        run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
+        shell: bash

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 Django Password Validators
 ==========================
 
+.. image:: https://github.com/fizista/django-password-validators/actions/workflows/ci.yml/badge.svg?branch=master
+    :target: https://github.com/fizista/django-password-validators/actions/workflows/ci.yml?query=branch%3Amaster
+    :alt: CI status
+
 Additional libraries for validating passwords in Django 2.2.25 or later.
 
 django-password-validators requires Django 2.2.25 or greater.

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     django40: Django >= 4.0, < 4.1
 
 commands =
-    python -V {toxinidir}/tests/manage.py test
+    python -V
+    python {toxinidir}/tests/manage.py test
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ deps =
     django40: Django >= 4.0, < 4.1
 
 commands =
-    python -V
-    {toxinidir}/tests/manage.py test
+    python -V {toxinidir}/tests/manage.py test
 
 


### PR DESCRIPTION
I noticed there was no CI configured, this PR adds a basic one with the currently supported versions. They should probably be updated, but would be nice to get CI first. 

Due to GitHub actions security restrictions, a new workflow added from a fork won't run on PRs, so you can't see the status here, but you can see it in my fork: https://github.com/browniebroke/django-password-validators/actions